### PR TITLE
drop core from .NET CLI in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Visual Studio:
 PM> Install-Package EnvMapper
 ```
 
-.NET Core CLI:
+.NET CLI:
 
 ```bash
 dotnet add package EnvMapper


### PR DESCRIPTION
Microsoft is trying to drop "core" from .NET Core: https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-5 